### PR TITLE
Don't throw MissingPropertyException if enableJetifier property is not set

### DIFF
--- a/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/CanIDropJetifierTask.kt
+++ b/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/CanIDropJetifierTask.kt
@@ -36,7 +36,7 @@ class CanIDropJetifierTask : AllOpenTask() {
 
     @TaskAction
     fun canIDropJetifier() {
-        if (project.property("android.enableJetifier") == "true") {
+        if (project.findProperty("android.enableJetifier") == "true") {
             throw GradleException(
                 "To work correctly, this task needs to be run with Jetifier turned off:" +
                         " ./gradlew -Pandroid.enableJetifier=false canIDropJetifier"


### PR DESCRIPTION
If the `android.enableJetifier` flag is not set at all (for example if you remove or comment the line in `gradle.properties`), a `MissingPropertyException` is thrown:

```bash
> Could not get unknown property 'android.enableJetifier' for project ':xy' of type org.gradle.api.Project.
```

However, as the flag is `false` by default if it is not specified, it should be safe to use `findPropery` which returns `null` if the property is not found instead of `property` which throws the exception.