### PR TITLE
Added assertive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Cannot drop Jetifier due to following external dependencies:
 
 ``` groovy
 canIDropJetifier {
+  assertive = true // Default: false, set to true to about the build in case a dependency on old artifacts is found
   verbose = true // Default: false, set to true to print the dependencies tree down to the old artifact
   includeModules = false // Default: true, print out not only external (library) dependencies, but also module dependencies that use old artifacts
   analyzeOnlyAndroidModules = false // Default: true, analyze only modules that use com.android.application or com.android.library plugins

--- a/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/Assertive.kt
+++ b/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/Assertive.kt
@@ -1,0 +1,44 @@
+package com.github.plnice.canidropjetifier
+
+import org.gradle.api.GradleException
+
+
+interface IAssertive {
+    /**
+     * Take note of the bad dependencies.
+     * @param dependencies a list of bad deps (can be empty)
+     */
+    fun note(dependencies: List<BlamedDependency>)
+
+    /**
+     * Assert that the dependencies are OK to continue the build.
+     *
+     * Concrete implementation shall inspect the list of dependencies collected through
+     * [IAssertive.note] and make the decision. In case of NO-GO it throws [GradleException].
+     *
+     * @throws GradleException - in case the deps evaluated NO-GO
+     */
+    fun assert()
+}
+
+class IgnoreAll : IAssertive {
+    override fun note(dependencies: List<BlamedDependency>) { /* Do nothing */ }
+    override fun assert() { /* Do nothing */ }
+}
+
+class StrictAssert : IAssertive {
+    private val blamed = ArrayList<BlamedDependency>()
+
+    override fun note(dependencies: List<BlamedDependency>) {
+        blamed.addAll(dependencies)
+    }
+
+    override fun assert() {
+        if (blamed.isNotEmpty()) {
+            throw GradleException("STOPPING the build: found dependencies on pre-AndroidX artifacts, Jetifier can NOT be dropped.\n" +
+                    "Scroll up the build log to see the blamed dependencies pretty-printed.\n" +
+                    "You can set `verbose = true` in this plugin's configuration to see more details.\n" +
+                    "Blamed dependencies:\n$blamed")
+        }
+    }
+}

--- a/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/CanIDropJetifierPlugin.kt
+++ b/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/CanIDropJetifierPlugin.kt
@@ -12,6 +12,7 @@ open class CanIDropJetifierPluginExtension {
     var configurationRegex: String = ".*RuntimeClasspath"
     var parallelMode: Boolean = false
     var parallelModePoolSize: Int? = null
+    var assertive: Boolean = false
 }
 
 class CanIDropJetifierPlugin : AllOpenPlugin<Project> {
@@ -26,6 +27,7 @@ class CanIDropJetifierPlugin : AllOpenPlugin<Project> {
                 configurationRegex = extension.configurationRegex
                 parallelMode = extension.parallelMode
                 parallelModePoolSize = extension.parallelModePoolSize
+                enforcer = if (extension.assertive) StrictAssert() else IgnoreAll()
             })
         }
     }

--- a/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/CanIDropJetifierTask.kt
+++ b/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/CanIDropJetifierTask.kt
@@ -26,6 +26,7 @@ class CanIDropJetifierTask : AllOpenTask() {
     var parallelModePoolSize: Int? = null
 
     private val reporter by lazy { TextCanIDropJetifierReporter(verbose, includeModules) }
+    lateinit var enforcer: IAssertive
 
     init {
         description = "Checks whether there are any dependencies using support library instead of AndroidX artifacts."
@@ -66,7 +67,9 @@ class CanIDropJetifierTask : AllOpenTask() {
             .distinct()
             .let {
                 reporter.report(this, it)
+                enforcer.note(it)
             }
+        enforcer.assert();
     }
 
     private fun Project.shouldAnalyze(): Boolean = with(project.plugins) {


### PR DESCRIPTION
# Hello
Here at Klarna, after a long battle supplanting pre-AndroidX dependencies, we're dropping the Jetifier. This speeds up the build a lot. Unfortunately, a risk persists that later a developer, unknowingly, adds a library which still depends on pre-AndroidX stuff. This would result in producing an APK with the support package included, which is highly unwanted.

To prevent such illy-packaged APKs, we keep `can-i-drop-jetifier` as a safety net. We added **assertive mode** which stops the build altogether in case an unwanted dependency is found. Gradle task `canIDropJetifier` is executed among other steps in our CI build.

We hope this small addition helps other people to guard their builds against unwanted stuff.

# Who'd find it useful
People whose project involves a big number of dependencies (e.g. in the order of hundreds) would benefit dropping the Jetifier the most. However, after dropping it, they run a risk of producing non-jetified APKs. They can mitigate this risk by using `can-i-drop-jetifier` in assertive mode.

# Assertive mode
In assertive mode, the plugin shall abort the build with exception like this:

```text
> Task :canIDropJetifier FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':canIDropJetifier'.
> STOPPING the build: found dependencies on pre-AndroidX artifacts, Jetifier can NOT be dropped.
  Scroll up the build log to see the blamed dependencies pretty-printed.
  You can set `verbose = true` in this plugin's configuration to see more details.
  Blamed dependencies: 
  [ChildDependency(parents=[External(name=com.klarna.mobile:sdk:2.0.25)], dependency=External(name=com.android.support:customtabs:28.0.0))...
```


Assertive mode is configurable via `assertive = true|false`, see README section 'Configuration'. The default value is `false` so the old behaviour is preserved.

Those who want to use new behavior need to update their gradle script:
``` groovy
canIDropJetifier {
  assertive = true // Default: false, set to true to about the build in case a dependency on old artifacts is found
  ...
}
```
Those who want to keep the old behavior don't need to change anything.