### PR TITLE
Gradle 7 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,11 @@ buildscript {
     repositories {
         google()
         jcenter()
-        
+
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.5.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.20")
     }
 }
 

--- a/canidropjetifier/build.gradle.kts
+++ b/canidropjetifier/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     `kotlin-dsl`
     `maven-publish`
-    id("org.jetbrains.kotlin.plugin.allopen") version "1.3.50"
+    id("org.jetbrains.kotlin.plugin.allopen") version "1.5.20"
     id("com.gradle.plugin-publish") version "0.10.1"
 }
 

--- a/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/CanIDropJetifierTask.kt
+++ b/canidropjetifier/src/main/kotlin/com.github.plnice/canidropjetifier/CanIDropJetifierTask.kt
@@ -8,6 +8,7 @@ import com.github.plnice.canidropjetifier.BlamedDependency.ChildDependency
 import com.github.plnice.canidropjetifier.BlamedDependency.FirstLevelDependency
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.tasks.Internal
 import java.util.*
 import java.util.concurrent.ForkJoinPool
 import java.util.function.Consumer
@@ -18,12 +19,12 @@ class CanIDropJetifierTask : AllOpenTask() {
         private val OLD_MODULES_PREFIXES = listOf("android.arch", "com.android.support")
     }
 
-    var verbose: Boolean = false
-    var includeModules: Boolean = true
-    var analyzeOnlyAndroidModules = true
-    lateinit var configurationRegex: String
-    var parallelMode = false
-    var parallelModePoolSize: Int? = null
+    @Internal var verbose: Boolean = false
+    @Internal var includeModules: Boolean = true
+    @Internal var analyzeOnlyAndroidModules = true
+    @Internal lateinit var configurationRegex: String
+    @Internal var parallelMode = false
+    @Internal var parallelModePoolSize: Int? = null
 
     private val reporter by lazy { TextCanIDropJetifierReporter(verbose, includeModules) }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample-dependency/build.gradle.kts
+++ b/sample-dependency/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("android.extensions")
 }
 
 android {
@@ -23,7 +22,6 @@ android {
 
 dependencies {
     implementation(fileTree("libs").matching { include("*.jar") })
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50")
     implementation("androidx.appcompat:appcompat:1.0.2")
     implementation("androidx.core:core-ktx:1.0.1")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.android.application")
     kotlin("android")
-    kotlin("android.extensions")
 
     id("com.github.plnice.canidropjetifier") version "0.5"
 }
@@ -26,7 +25,6 @@ android {
 
 dependencies {
     implementation(fileTree("libs").matching { include("*.jar") })
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50")
     implementation("androidx.appcompat:appcompat:1.0.2")
     implementation("androidx.core:core-ktx:1.0.1")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")


### PR DESCRIPTION
I want to use this plugin with gradle 7.

I quickly applied suggestions.

Changes:
* Update gradle to 7.1
* Update kotlin to 1.5
* Mark properties as internal

Tested:
* Pushed new version of plugin to maven local
* Updated sample and run check task with it
* Got a green build with success message

```========================================
Project sample
========================================

No dependencies on old artifacts! Safe to drop Jetifier.
```